### PR TITLE
修复地支错别字 Fix Earthly Branch Typos

### DIFF
--- a/lib/lunar_calendar.rb
+++ b/lib/lunar_calendar.rb
@@ -13,7 +13,7 @@ module LunarCalendar
   HEAVENLY_STEMS = %w[甲 乙 丙 丁 戊 己 庚 辛 壬 癸].freeze
 
   # @since 0.1.0
-  EARTHLY_STEMS = %w[子 丑 寅 卯 辰 已 午 未 申 西 戌 亥].freeze
+  EARTHLY_STEMS = %w[子 丑 寅 卯 辰 巳 午 未 申 酉 戌 亥].freeze
 
   # Convert Solar to Lunar
   #


### PR DESCRIPTION
已 -> 巳
西 -> 酉